### PR TITLE
1 Fixed. PadBuffer will make a wrong length in somecase.

### DIFF
--- a/MyAES/AES.cs
+++ b/MyAES/AES.cs
@@ -543,7 +543,7 @@ namespace MyAES {
 
 		// Pad to one extra block of size blocksize
 		private static byte[] PadBuffer(byte[] buf, int blocksize, Padding padding = Padding.PKCS7) {
-			return PadBuffer(buf, buf.Length, ((buf.Length / blocksize) + 1) * blocksize, padding);
+			return PadBuffer(buf, buf.Length, ((buf.Length / blocksize) + ((buf.Length % blocksize) > 0? 1: 0)) * blocksize, padding);
 		}
 
 		// Returns the number of bytes padding at the end of the buffer.


### PR DESCRIPTION
When the buf length is multiple  of 16, the PadBuffer will make a mistake.